### PR TITLE
Arrumando o processo de cegamente

### DIFF
--- a/src/ethowatcher.cpp
+++ b/src/ethowatcher.cpp
@@ -40,6 +40,7 @@ ethoWatcher::ethoWatcher(QWidget *parent) :
 
 //    ui->pbConversorXMLCSV->setVisible(false);
     ui->pbRealTime->setVisible(false);
+    ui->pbUnveil->setVisible(false);
 
     //ui->treeWidget->
 

--- a/src/moduloeditavideo.cpp
+++ b/src/moduloeditavideo.cpp
@@ -1764,27 +1764,9 @@ int moduloEditaVideo::getCodec(int indexCaixa)
     switch (indexCaixa)
     {
     case 0:
-
-        return CV_FOURCC('M','R','L','E'); //Microsoft RLE
-        //break;
-    case 1:
-
-        return CV_FOURCC('C','R','A','M'); //Microsoft Video 1
-
-    case 2:
-
-        return CV_FOURCC('I','Y','U','V'); //Intel IYUV Codec
-
-    case 3:
-        return CV_FOURCC('C','V','I','D'); //Cinepack Codec by radius
-        //break;
-    case 4:
-        return CV_FOURCC('L','A','G','S'); //Lagarith Lossles Codec
-
-    case 5:
         return CV_FOURCC('X','2','6','4'); //H264
 
-    case 6:
+    case 1:
         return CV_FOURCC('X','V','I','D');; //XVid MPeg-4 Codec
         //break;
     case -1:

--- a/src/teaconcordancia.ui
+++ b/src/teaconcordancia.ui
@@ -17,7 +17,7 @@
    <item>
     <widget class="QStackedWidget" name="swPrincipal">
      <property name="currentIndex">
-      <number>1</number>
+      <number>2</number>
      </property>
      <widget class="QWidget" name="page">
       <layout class="QVBoxLayout" name="verticalLayout_8">

--- a/src/telablind.cpp
+++ b/src/telablind.cpp
@@ -1001,7 +1001,7 @@ void telablind::on_pbBliding_clicked()
      textoEditado =ui->leNomePadr->text()+QString::number(jl);
 
      qDebug() << "arquivo vxml é o"<< nomeDosVideosAleatorizado[jl];
-     emit enviIncio(nomeDosVideosAleatorizado[jl],caminhoArquivo, textoEditado,ui->comboBoX->currentIndex());
+     emit enviIncio(nomeDosVideosAleatorizado[jl],caminhoArquivo, textoEditado, ui->comboBoX->currentIndex());
 
      disconnect(this,SIGNAL(enviIncio(QString,QString,QString,int)),listaEditaVideo[jl],SLOT(iniGraVidoCego(QString,QString,QString,int)));
 

--- a/src/telablind.cpp
+++ b/src/telablind.cpp
@@ -114,6 +114,7 @@ void telablind::on_pbAddListaVideo_clicked()
     //debug
     //ui->stackedWidget->setCurrentIndex(2);
 
+      ui->pbAddListaVideo->setEnabled(false);
 }
 
 void telablind::on_pbAbrirPasta_clicked()
@@ -150,6 +151,7 @@ void telablind::on_pbAbrirPasta_clicked()
 
 //    }
 
+    ui->pbAbrirPasta->setEnabled(false);
 
 
 

--- a/src/telablind.cpp
+++ b/src/telablind.cpp
@@ -526,6 +526,7 @@ void telablind::aleatorizaAOrdem(){
     //int posicaoDeEscrita=0;
     //encontra qual é o numero aleatorio maior e qual é sua posicao
     //alem disso esclui os arquivos que ja entraram
+    // count == quantidade de vídeos.
     for(int k=0; k<count; k++){
     int maiorValor=0;
     for(int i=0; i<count;i++){
@@ -542,7 +543,7 @@ void telablind::aleatorizaAOrdem(){
 
 
     }
-
+    //OU SEJA O 0 NESSE ARRAY VAI SER O VÍDEO BLIND 0
     nomeDosVideosAleatorizado.push_back(nomeDosVideos[posicao]);
     //frameInicialVideosAleatorizado.push_back();
 
@@ -1017,51 +1018,118 @@ void telablind::on_pbBliding_clicked()
     //editaVideo->iniGraVidoCego(listaVideo,caminhoArquivo,"patiRFID1Pati11l1");
 
     qDebug () <<"fim do TESTE" << QThread::currentThreadId();
+
+
+    this->grava_lista_chaves();
+
     //nomeDosVideosAleatorizado[i]
 }
 
-void telablind::on_pbSetUserKey_clicked()
-{
-    QString fonteVideo;
-    fonteVideo = QFileDialog::getOpenFileName(
-                this,
-                tr("Open File"),
-               "C:/ethowatcher/usuariosCadastrados",
-               "User Files (*.uxml)"
+
+void telablind::grava_lista_chaves(){
+
+    QString nomeArquivoGravarCsv;
+    nomeArquivoGravarCsv = QFileDialog::getSaveFileName(
+                 this,
+                 tr("Save File"),
+                 "C://",
+                "csv Files (*.csv)"
                 );
 
+    QFile outGravador;
+    outGravador.setFileName(nomeArquivoGravarCsv);
+    outGravador.open(QIODevice::WriteOnly | QIODevice::Text );
 
+    QTextStream csvGravador(&outGravador);
 
-    outputKey.setFileName(fonteVideo); //seta o nome do arquivo
+    csvGravador <<"sep=; \n";
+    csvGravador <<"EthoWatcher Open Source \n";
+    csvGravador <<"Observer" << experimentador.nome.toLatin1() << "\n";
+    csvGravador <<"Lab" << experimentador.lab.toLatin1() << "\n";
 
-    QXmlStreamReader xmlReader(&outputKey);
-    //output.open(QIODevice::ReadOnly | QIODevice::Text);
-    outputKey.open(QIODevice::ReadOnly | QIODevice::Text);
+    csvGravador <<" Blinded video register ;" <<"Original video register" << "\n"; //"Arquivo de cadastro do video original;" << "Arquivo de video original"<<
+    int ak=0;
+    int max=0;
+    int cont=0;
 
-    while(!xmlReader.atEnd() && !xmlReader.hasError()){
+    std::vector<QString> vxml;
 
+    for(int jl=0; jl<nomeDosVideosAleatorizado.size() ;jl++){
 
-        xmlReader.readNext();
-
-        //pega os nome dos arquivos que devem ser abertos
-        if(xmlReader.name()== "nome"){
-        expKey.nome = xmlReader.readElementText() ;
-
-        }
-
-        if(xmlReader.name() == "laboratorio"){
-
-            expKey.lab = xmlReader.readElementText() ;
-
-        }
-
-        if(xmlReader.name() == "password"){
-            expKey.senha = xmlReader.readElementText() ;
-        }
-
+      QString textoEditado;
+      textoEditado =ui->leNomePadr->text()+QString::number(jl);
+      csvGravador << caminhoArquivo +"/"+ textoEditado << ";" << nomeDosVideosAleatorizado[jl] <<"\n";
 
     }
-    output.close();
+
+
+    ////        vlay->addWidget(listaPB[jl]);
+
+    //    //colocando os botões no layute faz aparecer na tela
+    //    ui->saProgress->setLayout(vlay);
+
+
+    //    //comeca o blinding
+    //    listaEditaVideo[jl]->setKey(expKey.nome, expKey.lab, expKey.senha);
+    //     connect(this,SIGNAL(enviIncio(QString,QString,QString,int)),listaEditaVideo[jl],SLOT(iniGraVidoCego(QString,QString,QString,int)));
+    //     connect(listaEditaVideo[jl],SIGNAL(setProgres(int,int)),listaPB[jl],SLOT(setRange(int,int)));
+    //     connect(listaEditaVideo[jl],SIGNAL(frame(int)),listaPB[jl],SLOT(setValue(int)));
+    //     listaEditaVideo[jl]->moveToThread(listaDeThread[jl]);
+
+    //     listaDeThread[jl]->start();
+
+    //     QString textoEditado;
+    //     textoEditado =ui->leNomePadr->text()+QString::number(jl);
+
+    //     qDebug() << "arquivo vxml é o"<< nomeDosVideosAleatorizado[jl];
+
+    outGravador.close();
+}
+
+
+
+void telablind::on_pbSetUserKey_clicked()
+{
+//    QString fonteVideo;
+//    fonteVideo = QFileDialog::getOpenFileName(
+//                this,
+//                tr("Open File"),
+//               "C:/ethowatcher/usuariosCadastrados",
+//               "User Files (*.uxml)"
+//                );
+
+
+
+//    outputKey.setFileName(fonteVideo); //seta o nome do arquivo
+
+//    QXmlStreamReader xmlReader(&outputKey);
+//    //output.open(QIODevice::ReadOnly | QIODevice::Text);
+//    outputKey.open(QIODevice::ReadOnly | QIODevice::Text);
+
+//    while(!xmlReader.atEnd() && !xmlReader.hasError()){
+
+
+//        xmlReader.readNext();
+
+//        //pega os nome dos arquivos que devem ser abertos
+//        if(xmlReader.name()== "nome"){
+//        expKey.nome = xmlReader.readElementText() ;
+
+//        }
+
+//        if(xmlReader.name() == "laboratorio"){
+
+//            expKey.lab = xmlReader.readElementText() ;
+
+//        }
+
+//        if(xmlReader.name() == "password"){
+//            expKey.senha = xmlReader.readElementText() ;
+//        }
+
+
+//    }
+//    output.close();
 
 
 }

--- a/src/telablind.h
+++ b/src/telablind.h
@@ -334,7 +334,7 @@ private:
    QList <QProgressBar*> listaPB;
     void lerVXML(QString nomeArquivoLer);
 
-
+    void grava_lista_chaves();
 
 };
 

--- a/src/telablind.ui
+++ b/src/telablind.ui
@@ -18,21 +18,21 @@
     <widget class="QLabel" name="label">
      <property name="minimumSize">
       <size>
-       <width>0</width>
-       <height>100</height>
+       <width>500</width>
+       <height>80</height>
       </size>
      </property>
      <property name="maximumSize">
       <size>
-       <width>16777215</width>
-       <height>150</height>
+       <width>500</width>
+       <height>80</height>
       </size>
      </property>
      <property name="text">
       <string/>
      </property>
      <property name="pixmap">
-      <pixmap resource="resourcefile.qrc">:/icons/ethowatcher_logo_os.png</pixmap>
+      <pixmap resource="resourcefile.qrc">:/icons/logo_ethowatcher.png</pixmap>
      </property>
      <property name="scaledContents">
       <bool>true</bool>
@@ -283,7 +283,7 @@
                      <x>0</x>
                      <y>0</y>
                      <width>420</width>
-                     <height>246</height>
+                     <height>316</height>
                     </rect>
                    </property>
                    <layout class="QVBoxLayout" name="verticalLayout_5">

--- a/src/telablind.ui
+++ b/src/telablind.ui
@@ -69,7 +69,7 @@
                <item>
                 <widget class="QPushButton" name="pbAddListaVideo">
                  <property name="text">
-                  <string>Open List Video</string>
+                  <string>Open list video</string>
                  </property>
                 </widget>
                </item>
@@ -91,7 +91,7 @@
                <item>
                 <widget class="QPushButton" name="pbAbrirPasta">
                  <property name="text">
-                  <string>Set Destination Folder</string>
+                  <string>Set destination folder</string>
                  </property>
                 </widget>
                </item>
@@ -330,8 +330,8 @@
                     <rect>
                      <x>0</x>
                      <y>0</y>
-                     <width>43</width>
-                     <height>16</height>
+                     <width>98</width>
+                     <height>28</height>
                     </rect>
                    </property>
                   </widget>

--- a/src/telablind.ui
+++ b/src/telablind.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1017</width>
-    <height>833</height>
+    <width>998</width>
+    <height>535</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -47,9 +47,21 @@
         <layout class="QVBoxLayout" name="verticalLayout_8">
          <item>
           <widget class="QWidget" name="widget" native="true">
+           <property name="maximumSize">
+            <size>
+             <width>16777215</width>
+             <height>100</height>
+            </size>
+           </property>
            <layout class="QHBoxLayout" name="horizontalLayout_4">
             <item>
              <widget class="QGroupBox" name="groupBox">
+              <property name="maximumSize">
+               <size>
+                <width>16777215</width>
+                <height>100</height>
+               </size>
+              </property>
               <property name="title">
                <string>Step 1.01</string>
               </property>
@@ -66,6 +78,12 @@
             </item>
             <item>
              <widget class="QGroupBox" name="groupBox_2">
+              <property name="maximumSize">
+               <size>
+                <width>16777215</width>
+                <height>100</height>
+               </size>
+              </property>
               <property name="title">
                <string>Step 1.02</string>
               </property>
@@ -85,6 +103,12 @@
          </item>
          <item>
           <widget class="QWidget" name="widget_2" native="true">
+           <property name="maximumSize">
+            <size>
+             <width>16777215</width>
+             <height>100</height>
+            </size>
+           </property>
            <layout class="QHBoxLayout" name="horizontalLayout_5">
             <item>
              <widget class="QGroupBox" name="groupBox_5">
@@ -94,12 +118,24 @@
                 <height>100</height>
                </size>
               </property>
+              <property name="maximumSize">
+               <size>
+                <width>16777215</width>
+                <height>100</height>
+               </size>
+              </property>
               <property name="title">
                <string>Step 1.03</string>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_6">
                <item>
                 <widget class="QLabel" name="label_2">
+                 <property name="maximumSize">
+                  <size>
+                   <width>16777215</width>
+                   <height>30</height>
+                  </size>
+                 </property>
                  <property name="text">
                   <string>Blind name</string>
                  </property>
@@ -115,22 +151,6 @@
               </layout>
              </widget>
             </item>
-            <item>
-             <widget class="QGroupBox" name="groupBox_7">
-              <property name="title">
-               <string>Step 1.04</string>
-              </property>
-              <layout class="QHBoxLayout" name="horizontalLayout">
-               <item>
-                <widget class="QPushButton" name="pbSetUserKey">
-                 <property name="text">
-                  <string>Set User Key</string>
-                 </property>
-                </widget>
-               </item>
-              </layout>
-             </widget>
-            </item>
            </layout>
           </widget>
          </item>
@@ -139,12 +159,24 @@
            <layout class="QHBoxLayout" name="horizontalLayout_6">
             <item>
              <widget class="QGroupBox" name="groupBox_10">
+              <property name="maximumSize">
+               <size>
+                <width>16777215</width>
+                <height>100</height>
+               </size>
+              </property>
               <property name="title">
                <string>Step 1.05</string>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_7">
                <item>
                 <widget class="QLabel" name="label_26">
+                 <property name="maximumSize">
+                  <size>
+                   <width>16777215</width>
+                   <height>50</height>
+                  </size>
+                 </property>
                  <property name="text">
                   <string>Codec</string>
                  </property>
@@ -250,8 +282,8 @@
                     <rect>
                      <x>0</x>
                      <y>0</y>
-                     <width>429</width>
-                     <height>544</height>
+                     <width>420</width>
+                     <height>246</height>
                     </rect>
                    </property>
                    <layout class="QVBoxLayout" name="verticalLayout_5">
@@ -298,8 +330,8 @@
                     <rect>
                      <x>0</x>
                      <y>0</y>
-                     <width>98</width>
-                     <height>28</height>
+                     <width>43</width>
+                     <height>16</height>
                     </rect>
                    </property>
                   </widget>

--- a/src/telablind.ui
+++ b/src/telablind.ui
@@ -186,47 +186,12 @@
                 <widget class="QComboBox" name="comboBoX">
                  <item>
                   <property name="text">
-                   <string>Microsoft RLE</string>
-                  </property>
-                 </item>
-                 <item>
-                  <property name="text">
-                   <string>Microsoft Video1</string>
-                  </property>
-                 </item>
-                 <item>
-                  <property name="text">
-                   <string>Intel IYUV codec</string>
-                  </property>
-                 </item>
-                 <item>
-                  <property name="text">
-                   <string>Cinepack Codec by radius</string>
-                  </property>
-                 </item>
-                 <item>
-                  <property name="text">
-                   <string>Lagarith Lossles Codec</string>
-                  </property>
-                 </item>
-                 <item>
-                  <property name="text">
                    <string>H264</string>
                   </property>
                  </item>
                  <item>
                   <property name="text">
                    <string>XVid</string>
-                  </property>
-                 </item>
-                 <item>
-                  <property name="text">
-                   <string>ffdshow Video Codec</string>
-                  </property>
-                 </item>
-                 <item>
-                  <property name="text">
-                   <string>H264</string>
                   </property>
                  </item>
                 </widget>

--- a/src/telacadastrolistafilme.cpp
+++ b/src/telacadastrolistafilme.cpp
@@ -442,4 +442,10 @@ void telaCadastroListaFilme::on_pbGravarXML_clicked()
     stream.writeEndDocument(); //fecha o documento
     output.close(); //termina a gravacao
 
+
+    QMessageBox::information(this,tr("Message"),tr("Saved successfully"));
+
+    this->close();
+    delete this;
+
 }

--- a/src/telacadastrolistafilme.h
+++ b/src/telacadastrolistafilme.h
@@ -32,6 +32,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 #include <QString>
 #include <vector>
+#include <QMessageBox>
 
 namespace Ui {
 class telaCadastroListaFilme;

--- a/src/telacadastrolistafilme.ui
+++ b/src/telacadastrolistafilme.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>998</width>
-    <height>547</height>
+    <width>1023</width>
+    <height>656</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -57,69 +57,118 @@
           </attribute>
           <layout class="QVBoxLayout" name="verticalLayout">
            <item>
-            <widget class="QWidget" name="widget" native="true">
-             <layout class="QHBoxLayout" name="horizontalLayout">
+            <widget class="QWidget" name="widget_6" native="true">
+             <layout class="QHBoxLayout" name="horizontalLayout_7">
               <item>
-               <widget class="QLabel" name="label">
-                <property name="text">
-                 <string>Name</string>
+               <widget class="QWidget" name="widget_7" native="true">
+                <property name="minimumSize">
+                 <size>
+                  <width>400</width>
+                  <height>0</height>
+                 </size>
                 </property>
+                <layout class="QVBoxLayout" name="verticalLayout_4">
+                 <item>
+                  <widget class="QWidget" name="widget" native="true">
+                   <layout class="QHBoxLayout" name="horizontalLayout">
+                    <item>
+                     <widget class="QLabel" name="label">
+                      <property name="text">
+                       <string>Name</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <widget class="QLabel" name="lblNome">
+                      <property name="minimumSize">
+                       <size>
+                        <width>300</width>
+                        <height>0</height>
+                       </size>
+                      </property>
+                      <property name="autoFillBackground">
+                       <bool>true</bool>
+                      </property>
+                      <property name="text">
+                       <string/>
+                      </property>
+                     </widget>
+                    </item>
+                   </layout>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QWidget" name="widget_2" native="true">
+                   <layout class="QHBoxLayout" name="horizontalLayout_2">
+                    <item>
+                     <widget class="QLabel" name="label_4">
+                      <property name="text">
+                       <string>Path</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <widget class="QLabel" name="lblCaminho">
+                      <property name="minimumSize">
+                       <size>
+                        <width>300</width>
+                        <height>0</height>
+                       </size>
+                      </property>
+                      <property name="autoFillBackground">
+                       <bool>true</bool>
+                      </property>
+                      <property name="text">
+                       <string/>
+                      </property>
+                     </widget>
+                    </item>
+                   </layout>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QWidget" name="widget_3" native="true">
+                   <layout class="QHBoxLayout" name="horizontalLayout_3">
+                    <item>
+                     <widget class="QLabel" name="label_6">
+                      <property name="text">
+                       <string>Extension</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <widget class="QLabel" name="lblExtensao">
+                      <property name="minimumSize">
+                       <size>
+                        <width>300</width>
+                        <height>0</height>
+                       </size>
+                      </property>
+                      <property name="autoFillBackground">
+                       <bool>true</bool>
+                      </property>
+                      <property name="text">
+                       <string/>
+                      </property>
+                     </widget>
+                    </item>
+                   </layout>
+                  </widget>
+                 </item>
+                </layout>
+                <zorder>widget</zorder>
+                <zorder>widget</zorder>
+                <zorder>widget_2</zorder>
+                <zorder>widget_3</zorder>
                </widget>
               </item>
               <item>
-               <widget class="QLabel" name="lblNome">
-                <property name="autoFillBackground">
-                 <bool>true</bool>
-                </property>
-                <property name="text">
-                 <string/>
-                </property>
-               </widget>
-              </item>
-             </layout>
-            </widget>
-           </item>
-           <item>
-            <widget class="QWidget" name="widget_2" native="true">
-             <layout class="QHBoxLayout" name="horizontalLayout_2">
-              <item>
-               <widget class="QLabel" name="label_4">
-                <property name="text">
-                 <string>Path</string>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <widget class="QLabel" name="lblCaminho">
-                <property name="autoFillBackground">
-                 <bool>true</bool>
-                </property>
-                <property name="text">
-                 <string/>
-                </property>
-               </widget>
-              </item>
-             </layout>
-            </widget>
-           </item>
-           <item>
-            <widget class="QWidget" name="widget_3" native="true">
-             <layout class="QHBoxLayout" name="horizontalLayout_3">
-              <item>
-               <widget class="QLabel" name="label_6">
-                <property name="text">
-                 <string>Extension</string>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <widget class="QLabel" name="lblExtensao">
-                <property name="autoFillBackground">
-                 <bool>true</bool>
-                </property>
-                <property name="text">
-                 <string/>
-                </property>
+               <widget class="QWidget" name="widget_8" native="true">
+                <layout class="QVBoxLayout" name="verticalLayout_5">
+                 <item>
+                  <widget class="QListWidget" name="listWidget"/>
+                 </item>
+                </layout>
                </widget>
               </item>
              </layout>
@@ -136,46 +185,36 @@
                </widget>
               </item>
               <item>
-               <widget class="QPushButton" name="pbAddVideo">
-                <property name="enabled">
-                 <bool>false</bool>
-                </property>
-                <property name="text">
-                 <string>Add Video to list</string>
-                </property>
+               <widget class="QWidget" name="widget_9" native="true">
+                <layout class="QVBoxLayout" name="verticalLayout_6">
+                 <item>
+                  <widget class="QPushButton" name="pbAddVideo">
+                   <property name="enabled">
+                    <bool>false</bool>
+                   </property>
+                   <property name="text">
+                    <string>Add Video to list</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QPushButton" name="pbDeletar">
+                   <property name="text">
+                    <string>Delete</string>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
                </widget>
               </item>
              </layout>
             </widget>
            </item>
-          </layout>
-         </widget>
-         <widget class="QWidget" name="tab_2">
-          <attribute name="title">
-           <string>Video List Info</string>
-          </attribute>
-          <layout class="QVBoxLayout" name="verticalLayout_2">
            <item>
-            <widget class="QListWidget" name="listWidget"/>
-           </item>
-           <item>
-            <widget class="QWidget" name="widget_5" native="true">
-             <layout class="QHBoxLayout" name="horizontalLayout_5">
-              <item>
-               <widget class="QPushButton" name="pbDeletar">
-                <property name="text">
-                 <string>Delete</string>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <widget class="QPushButton" name="pbGravarXML">
-                <property name="text">
-                 <string>Save</string>
-                </property>
-               </widget>
-              </item>
-             </layout>
+            <widget class="QPushButton" name="pbGravarXML">
+             <property name="text">
+              <string>Save</string>
+             </property>
             </widget>
            </item>
           </layout>

--- a/src/telacadastropessoa.cpp
+++ b/src/telacadastropessoa.cpp
@@ -50,7 +50,7 @@ void telaCadastroPessoa::gravandoXML(){
     //stream.writeStartElement(nome);
     stream.writeTextElement("nome", nome);
     stream.writeTextElement("laboratorio", lab);
-    stream.writeTextElement("password", ui->lePass->text());
+//    stream.writeTextElement("password", ui->lePass->text());
 
 
     //stream.writeTextElement("sexo", sexo);

--- a/src/telacadastropessoa.ui
+++ b/src/telacadastropessoa.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>1002</width>
-    <height>577</height>
+    <height>545</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -65,20 +65,6 @@
        </item>
        <item>
         <widget class="QLineEdit" name="leLab"/>
-       </item>
-       <item>
-        <widget class="QLabel" name="label_2">
-         <property name="text">
-          <string>Password</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QLineEdit" name="lePass">
-         <property name="echoMode">
-          <enum>QLineEdit::Password</enum>
-         </property>
-        </widget>
        </item>
        <item>
         <widget class="QWidget" name="widget" native="true">


### PR DESCRIPTION
Essa proposta de atualização é para ajustar o processo de cegamente para que o relatório de vídeos seja criado durante o processo de cegamento e não mais dependa do arquivo de registro de usuário.

- Foi removido o campo de de password da janela de registro de usuário (#21).
- Arrumado a janela para o cadastro de lista de vídeos (#43). Faltou adicionar o botão de delete.
- Arrumado a janela de cegamento para que não seja mais necessário o uso de um documento de registro de usuário para o processo de cagamento (#44). O relatório que relaciona os vídeos cegados com os originais é criado durante a produção dos vídeos cegados. Sendo, assim não é mais necessário a janela de revelação dos vídeos e ela foi removida do programa.  O relatório do processo de cegamento precisa ser expandido. 
